### PR TITLE
Add support for m4v as 'video/x-m4v' MIME type

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ var mimeTypes = {
 	".f4v": "video/mp4",
 	".f4p": "video/mp4",
 	".mp4": "video/mp4",
+	".m4v": "video/x-m4v",
 	".asf": "video/x-ms-asf",
 	".asr": "video/x-ms-asf",
 	".asx": "video/x-ms-asf",


### PR DESCRIPTION
.m4v files are Apple's version of MPEG4 and according to ​http://en.wikipedia.org/wiki/M4V their mime.type is video/x-m4v